### PR TITLE
Add %boosters_active_list% placeholder

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
@@ -196,6 +196,26 @@ class Booster(
                 "${hh}:${mm}:${ss}"
             }
         )
+
+        PlaceholderManager.registerPlaceholder(
+            PlayerlessPlaceholder(
+                plugin,
+                "active_list",
+            ) {
+                var activeList = mutableListOf<String>()
+
+                for(active in Bukkit.getServer().activeBoosters){
+                    activeList.add(active.booster.name)
+                }
+
+                var outputString = plugin.langYml.getString("no-currently-active-list").formatEco(formatPlaceholders = false)
+                if (activeList.size > 0) {
+                    outputString = activeList.joinToString(", ")
+                }
+
+                outputString
+            }
+        )
     }
 
     override fun equals(other: Any?): Boolean {

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -18,4 +18,5 @@ messages:
   cannot-transmit: "&cYou can't transmit here!"
 
 no-currently-active: "&cNot Active!"
+no-currently-active-list: "&cThere isn't any booster active!"
 active-placeholder: "&fThanks %player% &ffor activating %booster%&f!"


### PR DESCRIPTION
Displays list of current active boosters comma separated

![image](https://user-images.githubusercontent.com/40837847/174445008-d0160f3f-a12e-449b-bce9-67abec64a6df.png)
_Screenshot made before changing no-currently-active-list message 😄_