### PR TITLE
Add active_ids_list placeholder and fix activation command replacement

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
@@ -6,7 +6,6 @@ import com.willfp.boosters.boosters.ActivatedBooster
 import com.willfp.boosters.boosters.Booster
 import com.willfp.boosters.boosters.Boosters
 import com.willfp.boosters.boosters.activateBooster
-import com.willfp.eco.core.data.ServerProfile
 import com.willfp.eco.core.data.profile
 import org.bukkit.Bukkit
 import org.bukkit.OfflinePlayer
@@ -53,10 +52,10 @@ fun Player.activateBooster(booster: Booster): Boolean {
         Bukkit.broadcastMessage(activationMessage)
     }
 
-    for (expiryCommand in booster.activationCommands) {
+    for (activationCommand in booster.activationCommands) {
         Bukkit.dispatchCommand(
             Bukkit.getConsoleSender(),
-            expiryCommand.replace("%player%", booster.active?.player?.name ?: "")
+            activationCommand.replace("%player%", this.name ?: "")
         )
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
@@ -222,6 +222,27 @@ class Booster(
                 outputString
             }
         )
+
+        PlaceholderManager.registerPlaceholder(
+            PlayerlessPlaceholder(
+                plugin,
+                "active_ids_list",
+            ) {
+                var activeList = mutableListOf<String>()
+
+                for (active in Bukkit.getServer().activeBoosters) {
+                    activeList.add(active.booster.getID())
+                }
+
+                var outputString =
+                    plugin.langYml.getString("no-currently-active-ids-list").formatEco(formatPlaceholders = false)
+                if (activeList.size > 0) {
+                    outputString = activeList.joinToString(",")
+                }
+
+                outputString
+            }
+        )
     }
 
     override fun getID(): String {

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -16,4 +16,5 @@ messages:
 
 no-currently-active: "&cNot Active!"
 no-currently-active-list: "&cThere isn't any booster active!"
+no-currently-active-ids-list: "None"
 active-placeholder: "&fThanks %player% &ffor activating %booster%&f!"


### PR DESCRIPTION
Hi, this is just a small PR with two changes:
- Add new placeholder called `active_ids_list` which provides a comma separated list of the IDs of all active boosters. This can be used for dynamically displaying booster info by iterating over all active boosters.
- Activation commands did not correctly replace the name of the "activating player" in commands.

Changes have been validated on my server but I don't have currently screenshots or output right now. They can be provided if you'd prefer to see some proofs of the change working.