### PR TITLE
feat: apply custom sound framework

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
@@ -14,7 +14,6 @@ import com.willfp.boosters.boosters.increaseBooster
 import com.willfp.eco.core.data.keys.PersistentDataKey
 import com.willfp.eco.core.data.keys.PersistentDataKeyType
 import com.willfp.eco.core.data.profile
-import com.willfp.eco.core.sound.AbstractPlayableSound
 import com.willfp.eco.core.sound.PlayableSound
 import com.willfp.eco.util.formatEco
 import com.willfp.eco.util.savedDisplayName
@@ -76,16 +75,16 @@ val consoleName: String
         .getFormattedString("console-displayname")
         .formatEco(formatPlaceholders = false)
 
-val activateSound: AbstractPlayableSound<*>?
+val activateSound
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.activate"))
 
-val incrementSound: AbstractPlayableSound<*>?
+val incrementSound
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.increment"))
 
-val expireSound: AbstractPlayableSound<*>?
+val expireSound
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.expire"))
 
-val expiryWarningSound: AbstractPlayableSound<*>?
+val expiryWarningSound
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.expiry-warning"))
 
 val expiryWarningIntervals: List<Int>

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
@@ -14,6 +14,7 @@ import com.willfp.boosters.boosters.increaseBooster
 import com.willfp.eco.core.data.keys.PersistentDataKey
 import com.willfp.eco.core.data.keys.PersistentDataKeyType
 import com.willfp.eco.core.data.profile
+import com.willfp.eco.core.sound.AbstractPlayableSound
 import com.willfp.eco.core.sound.PlayableSound
 import com.willfp.eco.util.formatEco
 import com.willfp.eco.util.savedDisplayName
@@ -75,16 +76,16 @@ val consoleName: String
         .getFormattedString("console-displayname")
         .formatEco(formatPlaceholders = false)
 
-val activateSound: PlayableSound?
+val activateSound: AbstractPlayableSound<*>?
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.activate"))
 
-val incrementSound: PlayableSound?
+val incrementSound: AbstractPlayableSound<*>?
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.increment"))
 
-val expireSound: PlayableSound?
+val expireSound: AbstractPlayableSound<*>?
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.expire"))
 
-val expiryWarningSound: PlayableSound?
+val expiryWarningSound: AbstractPlayableSound<*>?
     get() = PlayableSound.create(plugin.configYml.getSubsection("sounds.expiry-warning"))
 
 val expiryWarningIntervals: List<Int>


### PR DESCRIPTION
## Summary
- eco's sound API is now generic (`AbstractPlayableSound<T>`). `PlayableSound.create()` still delegates straight through to it and already returns/supports custom sounds identically, so call sites don't need to change.
- The only real break: `BoosterUtils.kt` explicitly typed `activateSound`/`incrementSound`/`expireSound`/`expiryWarningSound` as `PlayableSound?`, which no longer matches the value returned. Widened those declared types to `AbstractPlayableSound<*>?`.

## Test plan
- [ ] `./gradlew compileKotlin` succeeds against local eco 2026.28.1