### PR TITLE
feat: add global-effects sections [EcoHub-11]

### DIFF
--- a/documentation/boosters/how-to-make-a-custom-booster.md
+++ b/documentation/boosters/how-to-make-a-custom-booster.md
@@ -65,6 +65,11 @@ increment-effects: [] # Run when an active booster's duration is extended
 queue-effects: [] # Run when the booster is queued behind an active one in its category
 queue-increment-effects: [] # Run when a queued booster's duration is extended
 expiry-effects: [] # Run when the booster ends
+global-activation-effects: # Run once when the booster is activated, not once per player
+  - id: run_command
+    args:
+      command: "broadcast A 1.5x Sell Multiplier Booster is now active!"
+global-expiry-effects: [] # Run once when the booster ends, not once per player
 effects: # Run for the whole duration; this is the booster's functionality
   - id: sell_multiplier
     args:
@@ -122,6 +127,16 @@ increment-effects: [] # Run when an active booster's duration is extended
 queue-effects: [] # Run when the booster is queued behind an active one in its category
 queue-increment-effects: [] # Run when a queued booster's duration is extended
 expiry-effects: [] # Run when the booster ends
+
+# The global- blocks run a single time rather than once per online player.
+# Use them for console commands, which would otherwise run once for every player online.
+# No player is attached, so %player% is empty and player-specific effects
+# (send_message, give_item, etc.) will not run - put those in the blocks above.
+global-activation-effects: # Run once when the booster is activated
+  - id: run_command
+    args:
+      command: "broadcast A 1.5x Sell Multiplier Booster is now active!"
+global-expiry-effects: [] # Run once when the booster ends
 
 effects: # Run for the whole duration; this is the booster's functionality
   - id: sell_multiplier

--- a/documentation/boosters/how-to-make-a-custom-booster.md
+++ b/documentation/boosters/how-to-make-a-custom-booster.md
@@ -69,6 +69,9 @@ global-activation-effects: # Run once when the booster is activated, not once pe
   - id: run_command
     args:
       command: "broadcast A 1.5x Sell Multiplier Booster is now active!"
+global-increment-effects: [] # Run once when the duration is extended, not once per player
+global-queue-effects: [] # Run once when the booster is queued, not once per player
+global-queue-increment-effects: [] # Run once when a queued booster is extended, not once per player
 global-expiry-effects: [] # Run once when the booster ends, not once per player
 effects: # Run for the whole duration; this is the booster's functionality
   - id: sell_multiplier
@@ -128,7 +131,8 @@ queue-effects: [] # Run when the booster is queued behind an active one in its c
 queue-increment-effects: [] # Run when a queued booster's duration is extended
 expiry-effects: [] # Run when the booster ends
 
-# The global- blocks run a single time rather than once per online player.
+# Every lifecycle block above has a global- counterpart that runs a single time
+# rather than once per online player.
 # Use them for console commands, which would otherwise run once for every player online.
 # No player is attached, so %player% is empty and player-specific effects
 # (send_message, give_item, etc.) will not run - put those in the blocks above.
@@ -136,6 +140,9 @@ global-activation-effects: # Run once when the booster is activated
   - id: run_command
     args:
       command: "broadcast A 1.5x Sell Multiplier Booster is now active!"
+global-increment-effects: [] # Run once when an active booster's duration is extended
+global-queue-effects: [] # Run once when the booster is queued
+global-queue-increment-effects: [] # Run once when a queued booster's duration is extended
 global-expiry-effects: [] # Run once when the booster ends
 
 effects: # Run for the whole duration; this is the booster's functionality

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
@@ -139,6 +139,7 @@ fun Booster.runExpiryWarning() {
 
 fun Server.activateBoosterConsole(booster: Booster): BoosterActivationResult {
     var effects: Chain?
+    var globalEffects: Chain?
     var status: ActivationResult
     var newTime = booster.duration.toLong()
 
@@ -147,12 +148,14 @@ fun Server.activateBoosterConsole(booster: Booster): BoosterActivationResult {
 
     if (toMergeWith != null) {
         effects = booster.incrementEffects
+        globalEffects = booster.globalIncrementEffects
         newTime += toMergeWith.booster.secondsLeft * 20
         status = ActivationResult.MERGED
     } else if (blocking != null) {
         val isQueueMerge = BoosterQueue.shouldMergeInQueue(booster)
 
         effects = if (isQueueMerge > 0) booster.queueIncrementEffects else booster.queueEffects
+        globalEffects = if (isQueueMerge > 0) booster.globalQueueIncrementEffects else booster.globalQueueEffects
         status = ActivationResult.QUEUED
 
         if (isQueueMerge > 0) {
@@ -163,6 +166,7 @@ fun Server.activateBoosterConsole(booster: Booster): BoosterActivationResult {
     } else {
         status = ActivationResult.ACTIVATED
         effects = booster.activationEffects
+        globalEffects = booster.globalActivationEffects
     }
 
     Bukkit.getOnlinePlayers().forEach { target ->
@@ -180,11 +184,6 @@ fun Server.activateBoosterConsole(booster: Booster): BoosterActivationResult {
         ActivationResult.ACTIVATED -> {
             this.activateBooster(ActivatedBooster(booster, null))
 
-            booster.globalActivationEffects.triggerGlobally(
-                NamedValue("activator", consoleName),
-                NamedValue("time", booster.getFormattedTimeLeft(newTime.toInt() / 20))
-            )
-
             for (player in Bukkit.getOnlinePlayers()) {
                 activateSound?.playTo(player)
             }
@@ -201,6 +200,11 @@ fun Server.activateBoosterConsole(booster: Booster): BoosterActivationResult {
         else -> {}
     }
 
+    globalEffects.triggerGlobally(
+        NamedValue("activator", consoleName),
+        NamedValue("time", booster.getFormattedTimeLeft(newTime.toInt() / 20))
+    )
+
     return BoosterActivationResult(status, newTime)
 }
 
@@ -214,6 +218,10 @@ fun Server.incrementBoosterConsole(booster: Booster) {
     }
 
     Bukkit.getServer().increaseBooster(booster)
+
+    booster.globalIncrementEffects.triggerGlobally(
+        NamedValue("activator", consoleName)
+    )
 
     for (player in Bukkit.getOnlinePlayers()) {
         incrementSound?.playTo(player)
@@ -236,6 +244,7 @@ fun Player.activateBooster(booster: Booster): BoosterActivationResult {
     this.setAmountOfBooster(booster, amount - 1)
 
     var effects: Chain?
+    var globalEffects: Chain?
     var status: ActivationResult
     var newTime = booster.duration.toLong()
 
@@ -244,12 +253,14 @@ fun Player.activateBooster(booster: Booster): BoosterActivationResult {
 
     if (toMergeWith != null) {
         effects = booster.incrementEffects
+        globalEffects = booster.globalIncrementEffects
         newTime += toMergeWith.booster.secondsLeft * 20
         status = ActivationResult.MERGED
     } else if (blocking != null) {
         val isQueueMerge = BoosterQueue.shouldMergeInQueue(booster)
 
         effects = if (isQueueMerge > 0) booster.queueIncrementEffects else booster.queueEffects
+        globalEffects = if (isQueueMerge > 0) booster.globalQueueIncrementEffects else booster.globalQueueEffects
         status = ActivationResult.QUEUED
 
         if (isQueueMerge > 0) {
@@ -260,15 +271,11 @@ fun Player.activateBooster(booster: Booster): BoosterActivationResult {
     } else {
         status = ActivationResult.ACTIVATED
         effects = booster.activationEffects
+        globalEffects = booster.globalActivationEffects
     }
 
     if (status == ActivationResult.ACTIVATED) {
         Bukkit.getServer().activateBooster(ActivatedBooster(booster, this.uniqueId))
-
-        booster.globalActivationEffects.triggerGlobally(
-            NamedValue("activator", this.name),
-            NamedValue("time", booster.getFormattedTimeLeft(newTime.toInt() / 20))
-        )
 
         for (player in Bukkit.getOnlinePlayers()) {
             activateSound?.playTo(player)
@@ -280,6 +287,11 @@ fun Player.activateBooster(booster: Booster): BoosterActivationResult {
             incrementSound?.playTo(player)
         }
     }
+
+    globalEffects.triggerGlobally(
+        NamedValue("activator", this.name),
+        NamedValue("time", booster.getFormattedTimeLeft(newTime.toInt() / 20))
+    )
 
     if (effects != null) {
         Bukkit.getOnlinePlayers().forEach { target ->

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/BoosterUtils.kt
@@ -19,6 +19,7 @@ import com.willfp.eco.util.formatEco
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toComponent
 import com.willfp.libreforge.EmptyProvidedHolder
+import com.willfp.libreforge.GlobalDispatcher
 import com.willfp.libreforge.NamedValue
 import com.willfp.libreforge.effects.Chain
 import com.willfp.libreforge.toDispatcher
@@ -51,11 +52,31 @@ val OfflinePlayer.boosters: List<Booster>
 
 val serverUUID = UUID.fromString("00000fff-0000-0000-0000-000000000000")
 
+/**
+ * Trigger a chain a single time, server-wide, rather than once per online player.
+ *
+ * Runs under [GlobalDispatcher], which has no player attached, so %player% resolves
+ * to empty and player-scoped effects (send_message, give_item, ...) will not run.
+ */
+private fun Chain?.triggerGlobally(vararg placeholders: NamedValue) {
+    val chain = this ?: return
+
+    val dispatched = TriggerData().dispatch(GlobalDispatcher)
+
+    for (placeholder in placeholders) {
+        dispatched.addPlaceholder(placeholder)
+    }
+
+    chain.trigger(dispatched)
+}
+
 fun Booster.runExpiryEffects() {
     Bukkit.getOnlinePlayers().forEach { player ->
         this.expiryEffects?.trigger(player.toDispatcher())
         expireSound?.playTo(player)
     }
+
+    this.globalExpiryEffects.triggerGlobally()
 }
 
 fun OfflinePlayer.getAmountOfBooster(booster: Booster): Int {
@@ -159,6 +180,11 @@ fun Server.activateBoosterConsole(booster: Booster): BoosterActivationResult {
         ActivationResult.ACTIVATED -> {
             this.activateBooster(ActivatedBooster(booster, null))
 
+            booster.globalActivationEffects.triggerGlobally(
+                NamedValue("activator", consoleName),
+                NamedValue("time", booster.getFormattedTimeLeft(newTime.toInt() / 20))
+            )
+
             for (player in Bukkit.getOnlinePlayers()) {
                 activateSound?.playTo(player)
             }
@@ -239,6 +265,11 @@ fun Player.activateBooster(booster: Booster): BoosterActivationResult {
     if (status == ActivationResult.ACTIVATED) {
         Bukkit.getServer().activateBooster(ActivatedBooster(booster, this.uniqueId))
 
+        booster.globalActivationEffects.triggerGlobally(
+            NamedValue("activator", this.name),
+            NamedValue("time", booster.getFormattedTimeLeft(newTime.toInt() / 20))
+        )
+
         for (player in Bukkit.getOnlinePlayers()) {
             activateSound?.playTo(player)
         }
@@ -286,6 +317,11 @@ fun OfflinePlayer.activateQueuedBooster(booster: Booster, time: Long) {
         }
     }
 
+    booster.globalActivationEffects.triggerGlobally(
+        NamedValue("activator", player?.name ?: this.savedDisplayName),
+        NamedValue("time", booster.getFormattedTimeLeft(time.toInt() / 20))
+    )
+
     Bukkit.getServer().activateBooster(
         ActivatedBooster(booster, this.uniqueId),
         durationTicks = time.toInt()
@@ -313,6 +349,11 @@ fun Server.activateQueuedBoosterConsole(booster: Booster, time: Long) {
             booster.activationEffects.trigger(dispatched)
         }
     }
+
+    booster.globalActivationEffects.triggerGlobally(
+        NamedValue("activator", consoleName),
+        NamedValue("time", booster.getFormattedTimeLeft(time.toInt() / 20))
+    )
 
     this.activateBooster(
         ActivatedBooster(booster, null),

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
@@ -176,6 +176,12 @@ class Booster(
         ViolationContext(plugin, "Booster $id Queue Effects")
     )
 
+    val globalQueueEffects = Effects.compileChain(
+        config.getSubsections("global-queue-effects"),
+        NormalExecutorFactory.create(),
+        ViolationContext(plugin, "Booster $id Global Queue Effects")
+    )
+
     val expiryEffects = Effects.compileChain(
         config.getSubsections("expiry-effects"),
         NormalExecutorFactory.create(),
@@ -194,10 +200,22 @@ class Booster(
         ViolationContext(plugin, "Booster $id Increment Effects")
     )
 
+    val globalIncrementEffects = Effects.compileChain(
+        config.getSubsections("global-increment-effects"),
+        NormalExecutorFactory.create(),
+        ViolationContext(plugin, "Booster $id Global Increment Effects")
+    )
+
     val queueIncrementEffects = Effects.compileChain(
         config.getSubsections("queue-increment-effects"),
         NormalExecutorFactory.create(),
-        ViolationContext(plugin, "Booster $id Increment Effects")
+        ViolationContext(plugin, "Booster $id Queue Increment Effects")
+    )
+
+    val globalQueueIncrementEffects = Effects.compileChain(
+        config.getSubsections("global-queue-increment-effects"),
+        NormalExecutorFactory.create(),
+        ViolationContext(plugin, "Booster $id Global Queue Increment Effects")
     )
 
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/boosters/boosters/Booster.kt
@@ -164,6 +164,12 @@ class Booster(
         ViolationContext(plugin, "Booster $id Activation Effects")
     )
 
+    val globalActivationEffects = Effects.compileChain(
+        config.getSubsections("global-activation-effects"),
+        NormalExecutorFactory.create(),
+        ViolationContext(plugin, "Booster $id Global Activation Effects")
+    )
+
     val queueEffects = Effects.compileChain(
         config.getSubsections("queue-effects"),
         NormalExecutorFactory.create(),
@@ -174,6 +180,12 @@ class Booster(
         config.getSubsections("expiry-effects"),
         NormalExecutorFactory.create(),
         ViolationContext(plugin, "Booster $id Expiry Effects")
+    )
+
+    val globalExpiryEffects = Effects.compileChain(
+        config.getSubsections("global-expiry-effects"),
+        NormalExecutorFactory.create(),
+        ViolationContext(plugin, "Booster $id Global Expiry Effects")
     )
 
     val incrementEffects = Effects.compileChain(

--- a/eco-core/core-plugin/src/main/resources/boosters/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/boosters/_example.yml
@@ -52,6 +52,17 @@ activation-effects:
         - " &fThis booster will last %time%, be sure to thank them!"
         - ""
 
+# Effects to be run once when the Booster is activated (runs a single time, not per player)
+# Use this for console commands and anything else that should only happen once.
+# Because these run server-wide with no player attached, player-specific effects
+# (send_message, give_item, etc.) will not run here - put those in activation-effects.
+# %activator% - The player who activated the booster
+# %time% - The time remaining on the booster
+global-activation-effects:
+  - id: run_command
+    args:
+      command: "broadcast A 1.5x Sell Multiplier Booster is now active!"
+
 # Effects to be run when the Booster is incremented (applies to all players)
 # %activator% - The player who queued the booster
 # %player% - The player receiving the message/effect
@@ -105,6 +116,14 @@ expiry-effects:
         - " &fThe &a1.5x Sell Multiplier Booster&f has ended"
         - " &fGet another one here: &ahttps://store.ecomc.net/package/756887"
         - ""
+
+# Effects to be run once when the Booster expires (runs a single time, not per player)
+# Same rules as global-activation-effects: no player is attached, so use this for
+# console commands rather than player-specific effects.
+global-expiry-effects:
+  - id: run_command
+    args:
+      command: "broadcast The 1.5x Sell Multiplier Booster has ended!"
 
 gui:
   item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTM0YjI3YmZjYzhmOWI5NjQ1OTRiNjE4YjExNDZhZjY5ZGUyNzhjZTVlMmUzMDEyY2I0NzFhOWEzY2YzODcxIn19fQ==

--- a/eco-core/core-plugin/src/main/resources/boosters/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/boosters/_example.yml
@@ -77,6 +77,16 @@ increment-effects:
         - " &fThis booster will last %time%, be sure to thank them!"
         - ""
 
+# Effects to be run once when the Booster is incremented (runs a single time, not per player)
+# Same rules as global-activation-effects: no player is attached, so use this for
+# console commands rather than player-specific effects.
+# %activator% - The player who incremented the booster
+# %time% - The time remaining on the booster
+global-increment-effects:
+  - id: run_command
+    args:
+      command: "broadcast The 1.5x Sell Multiplier Booster has been extended!"
+
 # Effects to be run when the Booster is queued (applies to all players)
 # %activator% - The player who queued the booster
 # %player% - The player receiving the message/effect
@@ -91,6 +101,15 @@ queue-effects:
         - " &fThis booster will last %time%, when its time comes!"
         - ""
 
+# Effects to be run once when the Booster is queued (runs a single time, not per player)
+# Same rules as global-activation-effects: no player is attached, so use this for
+# console commands rather than player-specific effects.
+# %activator% - The player who queued the booster
+# %time% - The time the booster will last for
+global-queue-effects:
+  - id: run_command
+    args:
+      command: "broadcast A 1.5x Sell Multiplier Booster has been queued!"
 
 # Effects to be run when the Booster is incremented in the queue (applies to all players)
 # %activator% - The player who queued the booster
@@ -105,6 +124,16 @@ queue-increment-effects:
         - " %activator%&f has increased a &a1.5x Sell Multiplier Booster&f in the queue!"
         - " &fThis booster will now last %time%, when its time comes!"
         - ""
+
+# Effects to be run once when the Booster is incremented in the queue (runs a single time, not per player)
+# Same rules as global-activation-effects: no player is attached, so use this for
+# console commands rather than player-specific effects.
+# %activator% - The player who incremented the queued booster
+# %time% - The time the booster will last for
+global-queue-increment-effects:
+  - id: run_command
+    args:
+      command: "broadcast A queued 1.5x Sell Multiplier Booster has been extended!"
 
 # Effects to be run when the Booster expires (applies to all players)
 expiry-effects:


### PR DESCRIPTION
## Description

Adds mechanism to run effects via a `GlobalDispatcher` on activation and expiration of a booster.

### QA
<img width="666" height="132" alt="{6239211A-7CB7-4AC8-B35A-FCE4CF760805}" src="https://github.com/user-attachments/assets/87c968e1-9560-4d3c-883f-fff12f2f6ece" />

### QA Config
```YML
name: "Test 3x XP"
duration: 200 # 10 seconds - short on purpose for testing

category: "test"

merge-tag: "Test_XP"

expiry-warning: false # Duration is shorter than the warning intervals

# Vanilla XP multiplier - no external plugins required
effects:
  - id: xp_multiplier
    args:
      multiplier: 3
conditions: [ ]

activation-conditions: [ ]

# Per-player, runs for every online player
activation-effects:
  - id: send_message
    args:
      action_bar: false
      messages:
        - "&b[TEST] activation-effects &f(per player)"
        - "&f  activator: &b%activator%&f | time: &b%time%"

# Runs once, server-wide, no player attached
global-activation-effects:
  - id: run_command
    args:
      command: "say [TEST] global-activation-effects ran once (activator: %activator%, time: %time%)"

increment-effects:
  - id: send_message
    args:
      action_bar: false
      messages:
        - "&b[TEST] increment-effects &f(per player) - time: &b%time%"

queue-effects:
  - id: send_message
    args:
      action_bar: false
      messages:
        - "&b[TEST] queue-effects &f(per player) - time: &b%time%"

queue-increment-effects:
  - id: send_message
    args:
      action_bar: false
      messages:
        - "&b[TEST] queue-increment-effects &f(per player) - time: &b%time%"

# Per-player, runs for every online player
expiry-effects:
  - id: send_message
    args:
      action_bar: false
      messages:
        - "&b[TEST] expiry-effects &f(per player)"

# Runs once, server-wide, no player attached
global-expiry-effects:
  - id: run_command
    args:
      command: "say [TEST] global-expiry-effects ran once"

bossbar:
  enabled: true
  name: "&bTest 3x XP"
  color: BLUE
  style: SEGMENTED_10

gui:
  item: experience_bottle
  name: "&bTest 3x XP"
  lore:
    - ""
    - "&fVanilla XP multiplier, &b10 seconds&f."
    - "&fUsed to test activation/expiry effects."
    - ""
    - "&fYou have: &b%amount%"
    - ""
    - "&e&oClick to activate!"
    - ""
  position:
    page: 1
    row: 4
    column: 5
```
