### PR TITLE
Revert "EcoHub: Bump version to 2026.32.1."

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@
 eco-version=2026.32
 kotlin.code.style=official
 libreforge-version=2026.32
-version=2026.32.1
+version=2026.32


### PR DESCRIPTION
This reverts commit f405dd3bc97a2b1c425dc635ff3270ee04f63b4c.